### PR TITLE
Include endtime in results about each port

### DIFF
--- a/masscan/masscan.py
+++ b/masscan/masscan.py
@@ -403,6 +403,7 @@ class PortScanner(object):
             host = None
             address_block = {}
             vendor_block = {}
+            endtime = dhost.get('endtime')
             for address in dhost.findall('address'):
                 addtype = address.get('addrtype')
                 address_block[addtype] = address.get('addr')
@@ -431,6 +432,7 @@ class PortScanner(object):
                     'state': state,
                     'reason': reason,
                     'reason_ttl': reason_ttl,
+                    'endtime': endtime,
                 }
 
                 for service in dhost.findall('ports/port/service'):


### PR DESCRIPTION
I think it can be valueable to have in the results the time each port was found. This information is already included in the XML output of masscan. This simple patch adds that information to `scan_results`.

Before:

    "10.0.0.1": {
      "tcp": {
        "80": {
          "state": "open",
          "reason": "syn-ack",
          "reason_ttl": "63",
          "services": []
        }
      },
      "icmp": {
        "0": {
          "state": "open",
          "reason": "none",
          "reason_ttl": "63",
          "services": []
        }
      }
    }

After:

    "10.0.0.1": {
      "tcp": {
        "80": {
          "state": "open",
          "reason": "syn-ack",
          "reason_ttl": "63",
          "endtime": "1555237371",
          "services": []
        }
      },
      "icmp": {
        "0": {
          "state": "open",
          "reason": "none",
          "reason_ttl": "63",
          "endtime": "1555237377",
          "services": []
        }
      }
    }
