### PR TITLE
Remove shebang

### DIFF
--- a/masscan/__init__.py
+++ b/masscan/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+"""Init file for the masscan bindings."""
 from .masscan import *
 
 __author__ = 'MyKings (xsseroot@gmail.com)'

--- a/masscan/example.py
+++ b/masscan/example.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+"""Example to use python-masscan."""
 import sys
 
 import masscan

--- a/masscan/masscan.py
+++ b/masscan/masscan.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+"""Python Bindings to use masscan and access scan results."""
 import os
 import re
 import shlex


### PR DESCRIPTION
`python-masscan` is imported to use, thus there is no need for shebangs.

Otherwise the shebangs need to be removed during the build process of the package.

```bash
sed -i -e '/^#!\//, 1d' masscan/*.py
```

Related to #17 