### PR TITLE
Fixed installation error in python2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 2019/09/20 (v0.1.5)
+ - [bugfix] Fixed python2 installation
+
 ## 2019/09/01 (v0.1.4)
  - [bugfix] Better support for python3 #22
 

--- a/masscan/__init__.py
+++ b/masscan/__init__.py
@@ -3,6 +3,6 @@
 from .masscan import *
 
 __author__ = 'MyKings (xsseroot@gmail.com)'
-__version__ = '0.1.4'
-__last_modification__ = '2019.09.02'
+__version__ = '0.1.5'
+__last_modification__ = '2019.09.20'
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import io
 
 try:
     from setuptools import setup
@@ -16,10 +17,10 @@ IS_PY2 = sys.version_info[0] == 2
 here = os.path.abspath(os.path.dirname(__file__))
 
 if IS_PY2:
-    with open(os.path.join(here, 'README.rst')) as readme_file:
+    with io.open(os.path.join(here, 'README.rst')) as readme_file:
         long_description = readme_file.read()
 else:
-    with open(os.path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
+    with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
         long_description = readme_file.read()
 
 setup(


### PR DESCRIPTION
Replaced `open()` with `io.open()` for compatibility.
Issue: #23 